### PR TITLE
Fix Browser, Google App and etc. black screen

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -353,7 +353,7 @@
   <project path="external/ceres-solver" name="platform/external/ceres-solver" groups="pdk-cw-fs,pdk-fs" remote="aosp" />
   <project path="external/chromium-libpac" name="platform/external/chromium-libpac" groups="pdk-fs" remote="aosp" />
   <project path="external/chromium-trace" name="platform/external/chromium-trace" groups="pdk" remote="aosp" />
-  <project path="external/chromium-webview" name="pawitp/android_external_chromium-webview" remote="github" revision="aosp-6.0" />
+  <project path="external/chromium-webview" name="aidas957/android_external_chromium-webview" remote="github" revision="cm-13.0" />
   <project path="external/clang" name="platform/external/clang" groups="pdk" remote="aosp" />
   <project path="external/cmockery" name="platform/external/cmockery" groups="pdk-fs" remote="aosp" />
   <project path="external/compiler-rt" name="platform/external/compiler-rt" groups="pdk" remote="aosp" />


### PR DESCRIPTION
I fixed this by using older version of WebView (version 39)
Most of the internet-requiring apps are using WebView, so don't reject this
