### PR TITLE
Workaround for stock keyboard FC with GApps installed (Best solution)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -279,7 +279,7 @@
   <project path="packages/apps/TvSettings" name="CyanogenMod/android_packages_apps_TvSettings" groups="generic_fs" />
   <project path="packages/apps/UnifiedEmail" name="CyanogenMod/android_packages_apps_UnifiedEmail" groups="pdk-fs" />
   <project path="packages/experimental" name="CyanogenMod/android_packages_experimental" />
-  <project path="packages/inputmethods/LatinIME" name="CyanogenMod/android_packages_inputmethods_LatinIME" groups="pdk-fs" />
+  <project path="packages/inputmethods/LatinIME" name="aidas957/android_packages_inputmethods_LatinIME" remote="github" revision="cm-13.0" />
   <project path="packages/providers/BookmarkProvider" name="CyanogenMod/android_packages_providers_BookmarkProvider" groups="pdk-fs" />
   <project path="packages/providers/CalendarProvider" name="CyanogenMod/android_packages_providers_CalendarProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/CallLogProvider" name="CyanogenMod/android_packages_providers_CallLogProvider" groups="pdk-fs" />


### PR DESCRIPTION
This breaks Gesture Typing on stock keyboard (Do not reject this, once again) (Add this to the known issue list in your CM 13 thread and tell people to install Google Keyboard if they want Gesture Typing)
